### PR TITLE
Use https for git source

### DIFF
--- a/dice.cabal
+++ b/dice.cabal
@@ -23,7 +23,7 @@ extra-source-files:
 
 source-repository head
   type: git
-  location: git://github.com/ncfavier/dice.git
+  location: https://github.com/ncfavier/dice.git
 
 common common
   hs-source-dirs:       src


### PR DESCRIPTION
git:// is no longer supported by github.